### PR TITLE
Avoid Metamask legacy warning when fetching injected web3

### DIFF
--- a/src/district/ui/web3/utils.cljs
+++ b/src/district/ui/web3/utils.cljs
@@ -5,7 +5,7 @@
   "Determines if the `web3` object has been injected by an
   ethereum provider."
   []
-  (boolean (aget js/window "web3")))
+  (boolean (or (aget js/window "ethereum" ) (aget js/window "web3"))))
 
 
 (defn web3-legacy?


### PR DESCRIPTION
If trying to get window.web3, metamask shows a warning to alert the website is using this legacy.

This PR checks if the web3 is injected by checking first the newer window.ethereum, and only falling back to window.web3 in case the former is not present.